### PR TITLE
only use ubuntugis if we want qgis on 14.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,7 @@ provisioner:
   name: chef_zero
 
 platforms:
+  - name: ubuntu-16.04
   - name: ubuntu-14.04
 #  - name: centos-6.5
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,15 +9,6 @@ include_recipe 'chef-sugar::default'
 include_recipe 'apt::default'
 
 if ubuntu_after_or_at_saucy?
-
-  apt_repository 'qgis' do
-    uri   'http://qgis.org/ubuntugis/'
-    components ['main']
-    key 'D71472C4'
-    keyserver 'keyserver.ubuntu.com'
-    distribution node['lsb']['codename']
-  end
-
   apt_repository 'ubuntugis-unstable' do
     uri 'ppa:ubuntugis/ubuntugis-unstable'
     components ['main']
@@ -26,6 +17,5 @@ if ubuntu_after_or_at_saucy?
     distribution node['lsb']['codename']
   end
 
-  %w{ qgis python-qgis qgis-plugin-grass qgis-plugin-grass-common grass }.each { |p| package p }
-
+  package %w{ qgis python-qgis qgis-plugin-grass qgis-plugin-grass-common grass }
 end


### PR DESCRIPTION
Had to remove http://qgis.org/ubuntugis/ apt repo, the packages from there have problems resolving the correct dependencies on ubuntu 14.04 but seem to work find for 16.04.

This will limit the qgis version to 2.14.3 but works for both 14.04 and 16.04 while the other repo only works for 16.04 but has newer versions of qgis.

Closes #3 
