### PR TITLE
point to ubuntu stable apt - inspec tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,12 +2,16 @@
 driver:
   name: vagrant
 
+verifier:
+  name: inspec
+
 provisioner:
   name: chef_zero
 
 platforms:
   - name: ubuntu-16.04
   - name: ubuntu-14.04
+  - name: ubuntu-16.10
 #  - name: centos-6.5
 
 suites:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,10 +12,20 @@ platforms:
   - name: ubuntu-16.04
   - name: ubuntu-14.04
   - name: ubuntu-16.10
-#  - name: centos-6.5
+  - name: centos-6.8
 
 suites:
   - name: default
     run_list:
       - recipe[qgis::default]
+    attributes:
+    excludes:
+      - centos-6.8
+  - name: centos
+    run_list:
+      - recipe[qgis::default]
+    excludes:
+      - ubuntu-14.04
+      - ubuntu-16.04
+      - ubuntu-16.10
     attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -3,4 +3,3 @@ source 'https://supermarket.chef.io'
 metadata
 
 cookbook 'apt'
-cookbook 'chef-sugar'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,96 @@
+task default: :accept
+
+desc 'Run all acceptance tests'
+task accept: [:lint, :unit]
+
+desc 'Run linting tools -- foodcritic and rubocop'
+task :lint do
+  abort('You must bump the cookbook version') unless bumped_metadata?
+  sh 'chef exec foodcritic -X spec .'
+  sh 'chef exec cookstyle'
+end
+
+desc 'Run unit tests with ChefSpec'
+task :unit do
+  sh 'chef exec rspec --color -fd'
+end
+
+desc 'Run functional tests with Serverspec'
+task :functional do
+  sh 'chef exec kitchen test -c'
+end
+
+# rubocop:disable all
+namespace :kitchen do
+  desc 'Create default aws kitchen yaml'
+  task :aws do
+    require 'yaml'
+    yml = {
+      "driver" =>  {
+        "name" => "ec2",
+        "region" => "us-west-2",
+        "shared_credentials_profile" => "default",
+        "aws_ssh_key_id" => "id_rsa-aws-kitchen",
+        "security_group_ids" => ['test-kitchen'],
+        "destroy" => "always"
+      },
+      "platform" => {
+        "name" => ['centos-6']
+      },
+      "transport" => {
+        "ssh_key" => "<%=ENV['HOME']%>/.ssh/id_rsa-aws"
+      }
+    }
+
+    File.open('.kitchen.aws.yml', 'w') do |f|
+      f << yml.to_yaml
+    end
+  end
+end
+# rubocop:enable all
+
+# Based on delivery-truck
+def bumped_metadata?
+  require 'chef'
+  files_to_check = %w(
+    metadata\.(rb|json)
+    Berksfile
+    Berksfile\.lock
+    Policyfile\.rb
+    Policyfile\.lock\.json
+    recipes\/.*
+    attributes\/.*
+    libraries\/.*
+    files\/.*
+    templates\/.*
+  ).join('|')
+
+  if changed_files.any? { |f| /^(#{files_to_check})/ =~ f }
+    metadata = Chef::Cookbook::Metadata.new
+    metadata.from_file('metadata.rb')
+    base_metadata = Chef::Cookbook::Metadata.new
+    base_metadata.from_file(base_metadata_file)
+    FileUtils.safe_unlink(base_metadata_file)
+    base_metadata.nil? ||
+      metadata.version > base_metadata.version
+  else
+    true
+  end
+end
+
+def changed_files
+  shell_out!('git diff --name-only origin/master').stdout.chomp.split('\n')
+end
+
+def base_metadata_file
+  File.open('base_metadata.rb', 'w') do |f|
+    f << shell_out!('git show origin/master:metadata.rb').stdout.chomp
+  end unless File.exist?('base_metadata.rb')
+  'base_metadata.rb'
+end
+
+def shell_out!(command)
+  require 'mixlib/shellout'
+  cmd = Mixlib::ShellOut.new(command)
+  cmd.run_command
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,8 +7,8 @@ long_description 'This will install the Latest Release QGIS via their offical
 debian/ubuntu apt repositories.
 https://www.qgis.org/en/site/forusers/alldownloads.html#debian-ubuntu'
 version '0.3.0'
-source_url "https://github.com/dayne/qgis-cookbook"
-issues_url "https://github.com/dayne/qgis-cookbook/issues"
+source_url 'https://github.com/dayne/qgis-cookbook'
+issues_url 'https://github.com/dayne/qgis-cookbook/issues'
 
 supports 'ubuntu', '>= 14.04'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,14 +2,15 @@ name 'qgis'
 maintainer 'Dayne Broderson'
 maintainer_email 'broderson@gmail.com'
 license 'Apache 2.0'
-description 'Installs/Configures qgis'
-long_description 'Installs/Configures qgis'
-version '0.2.0'
+description 'Installs latest release QGIS for debian/ubuntu via their apt repo'
+long_description 'This will install the Latest Release QGIS via their offical
+debian/ubuntu apt repositories.
+https://www.qgis.org/en/site/forusers/alldownloads.html#debian-ubuntu'
+version '0.3.0'
 source_url "https://github.com/dayne/qgis-cookbook"
 issues_url "https://github.com/dayne/qgis-cookbook/issues"
 
 supports 'ubuntu', '>= 14.04'
 
 depends 'apt'
-depends 'chef-sugar'
-
+# depends 'chef-sugar'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,17 +5,16 @@
 # Copyright (c) 2015 The Authors, All Rights Reserved.
 #
 
-include_recipe 'chef-sugar::default'
+# include_recipe 'chef-sugar::default'
 include_recipe 'apt::default'
-
-if ubuntu_after_or_at_saucy?
-  apt_repository 'ubuntugis-unstable' do
-    uri 'ppa:ubuntugis/ubuntugis-unstable'
-    components ['main']
-    key '314DF160'
-    keyserver 'keyserver.ubuntu.com'
-    distribution node['lsb']['codename']
+if node['platform_family'] == 'debian'
+  apt_repository 'qgis-latest-debian' do
+      uri 'http://qgis.org/debian/'
+      components ['main']
+      keyserver 'keyserver.ubuntu.com'
+      key '073D307A618E5811'
+      action :add
   end
 
-  package %w{ qgis python-qgis qgis-plugin-grass qgis-plugin-grass-common grass }
+  package %w(qgis python-qgis qgis-plugin-grass)
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,11 +9,11 @@
 include_recipe 'apt::default'
 if node['platform_family'] == 'debian'
   apt_repository 'qgis-latest-debian' do
-      uri 'http://qgis.org/debian/'
-      components ['main']
-      keyserver 'keyserver.ubuntu.com'
-      key '073D307A618E5811'
-      action :add
+    uri 'http://qgis.org/debian/'
+    components ['main']
+    keyserver 'keyserver.ubuntu.com'
+    key '073D307A618E5811'
+    action :add
   end
 
   package %w(qgis python-qgis qgis-plugin-grass)

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 describe 'qgis::default' do
   context 'When all attributes are default, on an ubuntu platform' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new.(platform: 'ubuntu')
+      runner = ChefSpec::ServerRunner.new.call(platform: 'ubuntu')
       runner.converge(described_recipe)
     end
 
@@ -22,7 +22,7 @@ end
 describe 'qgis::centos' do
   context 'When all attributes are default, on an ubuntu platform' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new.(platform: 'centos')
+      runner = ChefSpec::ServerRunner.new.call(platform: 'centos')
       runner.converge(described_recipe)
     end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -18,3 +18,16 @@ describe 'qgis::default' do
     end
   end
 end
+
+describe 'qgis::centos' do
+  context 'When all attributes are default, on an ubuntu platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new.(platform: 'centos')
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+  end
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -7,9 +7,9 @@
 require 'spec_helper'
 
 describe 'qgis::default' do
-  context 'When all attributes are default, on an unspecified platform' do
+  context 'When all attributes are default, on an ubuntu platform' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new
+      runner = ChefSpec::ServerRunner.new.(platform: 'ubuntu')
       runner.converge(described_recipe)
     end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -6,28 +6,18 @@
 
 require 'spec_helper'
 
-describe 'qgis::default' do
-  context 'When all attributes are default, on an ubuntu platform' do
-    let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new.call(platform: 'ubuntu')
-      runner.converge(described_recipe)
-    end
+%w(14.04 16.04 16.10).each do |ver|
+  describe 'qgis::default' do
+    context "When all attributes are default, on an ubuntu #{ver} platform" do
+      let(:chef_run) do
+        runner = ChefSpec::ServerRunner.new(platform: 'ubuntu',
+                                            version: ver)
+        runner.converge(described_recipe)
+      end
 
-    it 'converges successfully' do
-      chef_run # This should not raise an error
-    end
-  end
-end
-
-describe 'qgis::centos' do
-  context 'When all attributes are default, on an ubuntu platform' do
-    let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new.call(platform: 'centos')
-      runner.converge(described_recipe)
-    end
-
-    it 'converges successfully' do
-      chef_run # This should not raise an error
+      it 'converges successfully' do
+        chef_run # This should not raise an error
+      end
     end
   end
 end

--- a/test/integration/centos/default_spec.rb
+++ b/test/integration/centos/default_spec.rb
@@ -1,0 +1,3 @@
+describe package('qgis') do
+  it { should_not be_installed }
+end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,0 +1,4 @@
+describe package('qgis') do
+  it { should be_installed }
+  its('version') { should be >= '1:2.18' }
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-describe 'qgis::default' do
-  # Serverspec examples can be found at
-  # http://serverspec.org/resource_types.html
-  it 'does something' do
-    skip 'Replace this with meaningful tests'
-  end
-end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,3 +1,0 @@
-require 'serverspec'
-
-set :backend, :exec


### PR DESCRIPTION
Remove need for chef sugar
Inspec tests verify we're getting at least 2.18 QGIS
Tested on 14.04, 16.04 and 16.10
Have a CentOS suite to confirm adding this doesn't cause unexpected sadness.  In future will look to adding CentOS support.